### PR TITLE
Move eligibility flow into separate json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,30 +20,32 @@ Additional resources:
 - Requirements ([1](docs/requirements_1.jpeg) & [2](docs/requirements_1.jpeg))
 
 ---
-Format Example for [eligibility-flow.json](eligibility-flow.json)
+####Format Example for [eligibility-flow.json](eligibility-flow.json)
 
 The file starts with two special properties:
-1. `"start":"question0"` 
+
+1. `"start":"question0"`
 start indicates what the initial question should be
+
 2. `"endStates":["eligible", "ineligible", "ineligible at this time"]`
 endStates is an array of the possible end states in the flow chart
 
 
 The remainder of the file is made up of the individual 'question' objects:
 ```
-"question0":{  
+"question0":{
       "questionText":"Do you have a case pending?",
-      "answers":[  
-         {  
+      "answers":[
+         {
             "answerText":"Yes",
             "next":"ineligible at this time"
          },
-         {  
+         {
             "answerText":"No",
             "next":"question1"
          }
       ],
-      "helperText":[  
+      "helperText":[
          "\"Pending\" refers to any case that is pending or has not been fully resolved. For example, if a case does not have a case disposition, it is likely a case pending."
       ]
    }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,46 @@ Additional resources:
 
 - [Flowchart](docs/flowchart.jpeg)
 - Requirements ([1](docs/requirements_1.jpeg) & [2](docs/requirements_1.jpeg))
+---
+Format Example for [eligibility-flow.json](eligibility-flow.json)
+
+The file starts with two special properties:
+1. `"start":"question0"` 
+start indicates what the initial question should be
+2. `"endStates":["eligible", "ineligible", "ineligible at this time"]`
+endStates is an array of the possible end states in the flow chart
+
+
+The remainder of the file is made up of the individual 'question' objects:
+```
+"question0":{  
+      "questionText":"Do you have a case pending?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"ineligible at this time"
+         },
+         {  
+            "answerText":"No",
+            "next":"question1"
+         }
+      ],
+      "helperText":[  
+         "\"Pending\" refers to any case that is pending or has not been fully resolved. For example, if a case does not have a case disposition, it is likely a case pending."
+      ]
+   }
+```
+
+
+questionText = question that will be displayed for the user 
+
+answerText = words that will be displayed on the buttons
+
+next = which should the user see next if they click this answer? must be the name of a question OR one of the options defined in endStates (see 2. above)
+
+helperText = definitions or explanations of legalese (this can be an empty) `"helperText":[]`
+
+note: If you need to use parentheses, this character must be 'escaped' with a backslash.  For example, "Pending" becomes `\"Pending\"`
 
 ---
 Developement guide:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Additional resources:
 
 - [Flowchart](docs/flowchart.jpeg)
 - Requirements ([1](docs/requirements_1.jpeg) & [2](docs/requirements_1.jpeg))
+
 ---
 Format Example for [eligibility-flow.json](eligibility-flow.json)
 

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -1,0 +1,178 @@
+[  
+   {  
+      "question":"Do you have a case pending?",
+      "yes":{  
+         "text":"Yes",
+         "next":"ineligible at this time"
+      },
+      "no":{  
+         "text":"No",
+         "next":1
+      }
+   },
+   {  
+      "question":"Are you sealing a conviction or a non-conviction?",
+      "yes":{  
+         "text":"Conviction",
+         "next":2
+      },
+      "no":{  
+         "text":"Non-conviction",
+         "next":5
+      }
+   },
+   {  
+      "question":"Is this an eligible misdemeanor/felony or an ineligible misdemeanor/felony?",
+      "yes":{  
+         "text":"Eligible misdemeanor or felony",
+         "next":3
+      },
+      "no":{  
+         "text":"Ineligible misdemeanor or felony",
+         "next":"ineligible"
+      }
+   },
+   {  
+      "question":"Have you subsequently been convicted of another crime in any jurisdiction?",
+      "yes":{  
+         "text":"Yes",
+         "next":"ineligible"
+      },
+      "no":{  
+         "text":"No",
+         "next":4
+      }
+   },
+   {  
+      "question":"Has it been 8 years since you were off papers?",
+      "yes":{  
+         "text":"Yes",
+         "next":"eligable"
+      },
+      "no":{  
+         "text":"No",
+         "next":"ineligible at this time"
+      }
+   },
+   {  
+      "question":"Is your non-conviction the result of a Deferred Sentencing Agreement?",
+      "yes":{  
+         "text":"Yes",
+         "next":7
+      },
+      "no":{  
+         "text":"No",
+         "next":6
+      }
+   },
+   {  
+      "question":"Do you also have an ineligible conviction on your record?",
+      "yes":{  
+         "text":"Yes",
+         "next":13
+      },
+      "no":{  
+         "text":"No",
+         "next":8
+      }
+   },
+   {  
+      "question":"Do you also have an ineligible conviction on your record?",
+      "yes":{  
+         "text":"Yes",
+         "next":"ineligible"
+      },
+      "no":{  
+         "text":"No",
+         "next":8
+      }
+   },
+   {  
+      "question":"Is the non-conviction for an eligible misdemeanor or an ineligible misdemeanor/felony?",
+      "yes":{  
+         "text":"Eligible misdemeanor/felony",
+         "next":12
+      },
+      "no":{  
+         "text":"Ineligible misdemeanor/felony",
+         "next":9
+      }
+   },
+   {  
+      "question":"Was the case terminated before charging by the prosectution (no papered)?",
+      "yes":{  
+         "text":"Yes",
+         "next":11
+      },
+      "no":{  
+         "text":"No",
+         "next":10
+      }
+   },
+   {  
+      "question":"Has it been 4 years since you were \"off papers\" for the felony non-conviction?",
+      "yes":{  
+         "text":"Yes",
+         "next":"eligable"
+      },
+      "no":{  
+         "text":"No",
+         "next":"ineligible at this time"
+      }
+   },
+   {  
+      "question":"Has it been 3 years since you were \"off papers\" for the felony non-conviction?",
+      "yes":{  
+         "text":"Yes",
+         "next":"eligable"
+      },
+      "no":{  
+         "text":"No",
+         "next":"ineligible at this time"
+      }
+   },
+   {  
+      "question":"Has it been two years since you were \"off papers\" for the misdemeanor non-conviction?",
+      "yes":{  
+         "text":"Yes",
+         "next":"eligable"
+      },
+      "no":{  
+         "text":"No",
+         "next":"ineligible at this time"
+      }
+   },
+   {  
+      "question":"Is the ineligible conviction for a felony or misdemeanor?",
+      "yes":{  
+         "text":"Felony",
+         "next":14
+      },
+      "no":{  
+         "text":"Misdemeanor",
+         "next":15
+      }
+   },
+   {  
+      "question":"Has it been 10 years since you were \"off papers\" for the misdemeanor conviction?",
+      "yes":{  
+         "text":"Yes",
+         "next":8
+      },
+      "no":{  
+         "text":"No",
+         "next":"ineligible at this time"
+      }
+   },
+   {  
+      "question":"Has it been 5 years since you were \"off papers\" for the misdemeanor conviction?",
+      "yes":{  
+         "text":"Yes",
+         "next":8
+      },
+      "no":{  
+         "text":"No",
+         "next":"ineligible at this time"
+      }
+   }
+]

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -56,7 +56,7 @@
       "helperText":[  
 
       ],
-      "showIneligibleMisdemeanors":"true"
+      "showIneligibleMisdemeanors":true
    },
 
    "question3":{  
@@ -159,7 +159,7 @@
       "helperText":[  
 
       ],
-      "showIneligibleMisdemeanors":"true"
+      "showIneligibleMisdemeanors":true
    },
 
    "question9":{  

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -20,7 +20,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Pending\" refers to any case that is pending or has not been fully resolved. For example, if a case does not have a case disposition, it is likely a case pending."
       ]
    },
 
@@ -37,7 +37,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Convicted\" refers to the judgment (sentence) on a verdict or a finding of guilty, a plea of guilty or a plea of nolo contendere, or a plea or verdict of not guilty by reason of insanity."
       ]
    },
 
@@ -89,7 +89,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
       ]
    },
 
@@ -106,7 +106,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Deferred Sentencing Agreement\" means ..."
       ]
    },
 
@@ -192,7 +192,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
       ]
    },
 
@@ -209,7 +209,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
       ]
    },
 
@@ -226,7 +226,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
       ]
    },
 
@@ -260,7 +260,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
       ]
    },
    
@@ -277,7 +277,7 @@
          }
       ],
       "helperText":[  
-
+         "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
       ]
    }
 }

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -1,178 +1,273 @@
-[  
-   {  
-      "question":"Do you have a case pending?",
-      "yes":{  
-         "text":"Yes",
-         "next":"ineligible at this time"
-      },
-      "no":{  
-         "text":"No",
-         "next":1
-      }
+{  
+   "question0":{  
+      "questionText":"Do you have a case pending?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"ineligible at this time"
+         },
+         {  
+            "answerText":"No",
+            "next":"question1"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Are you sealing a conviction or a non-conviction?",
-      "yes":{  
-         "text":"Conviction",
-         "next":2
-      },
-      "no":{  
-         "text":"Non-conviction",
-         "next":5
-      }
+
+   "question1":{  
+      "questionText":"Are you sealing a conviction or a non-conviction?",
+      "answers":[  
+         {  
+            "answerText":"Conviction",
+            "next":"question2"
+         },
+         {  
+            "answerText":"Non-conviction",
+            "next":"question5"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Is this an eligible misdemeanor/felony or an ineligible misdemeanor/felony?",
-      "yes":{  
-         "text":"Eligible misdemeanor or felony",
-         "next":3
-      },
-      "no":{  
-         "text":"Ineligible misdemeanor or felony",
-         "next":"ineligible"
-      }
+
+   "question2":{  
+      "questionText":"Is this an eligible misdemeanor/felony or an ineligible misdemeanor/felony?",
+      "answers":[  
+         {  
+            "answerText":"Eligible misdemeanor or felony",
+            "next":"question3"
+         },
+         {  
+            "answerText":"Ineligible misdemeanor or felony",
+            "next":"ineligible"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Have you subsequently been convicted of another crime in any jurisdiction?",
-      "yes":{  
-         "text":"Yes",
-         "next":"ineligible"
-      },
-      "no":{  
-         "text":"No",
-         "next":4
-      }
+
+   "question3":{  
+      "questionText":"Have you subsequently been convicted of another crime in any jurisdiction?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"ineligible"
+         },
+         {  
+            "answerText":"No",
+            "next":"question4"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Has it been 8 years since you were off papers?",
-      "yes":{  
-         "text":"Yes",
-         "next":"eligable"
-      },
-      "no":{  
-         "text":"No",
-         "next":"ineligible at this time"
-      }
+
+   "question4":{  
+      "questionText":"Has it been 8 years since you were off papers?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"eligible"
+         },
+         {  
+            "answerText":"No",
+            "next":"ineligible at this time"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Is your non-conviction the result of a Deferred Sentencing Agreement?",
-      "yes":{  
-         "text":"Yes",
-         "next":7
-      },
-      "no":{  
-         "text":"No",
-         "next":6
-      }
+
+   "question5":{  
+      "questionText":"Is your non-conviction the result of a Deferred Sentencing Agreement?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"question7"
+         },
+         {  
+            "answerText":"No",
+            "next":"question6"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Do you also have an ineligible conviction on your record?",
-      "yes":{  
-         "text":"Yes",
-         "next":13
-      },
-      "no":{  
-         "text":"No",
-         "next":8
-      }
+
+   "question6":{  
+      "questionText":"Do you also have an ineligible conviction on your record?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"question13"
+         },
+         {  
+            "answerText":"No",
+            "next":"question8"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Do you also have an ineligible conviction on your record?",
-      "yes":{  
-         "text":"Yes",
-         "next":"ineligible"
-      },
-      "no":{  
-         "text":"No",
-         "next":8
-      }
+
+   "question7":{  
+      "questionText":"Do you also have an ineligible conviction on your record?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"ineligible"
+         },
+         {  
+            "answerText":"No",
+            "next":"question8"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Is the non-conviction for an eligible misdemeanor or an ineligible misdemeanor/felony?",
-      "yes":{  
-         "text":"Eligible misdemeanor/felony",
-         "next":12
-      },
-      "no":{  
-         "text":"Ineligible misdemeanor/felony",
-         "next":9
-      }
+
+   "question8":{  
+      "questionText":"Is the non-conviction for an eligible misdemeanor or an ineligible misdemeanor/felony?",
+      "answers":[  
+         {  
+            "answerText":"Eligible misdemeanor/felony",
+            "next":"question12"
+         },
+         {  
+            "answerText":"Ineligible misdemeanor/felony",
+            "next":"question9"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Was the case terminated before charging by the prosectution (no papered)?",
-      "yes":{  
-         "text":"Yes",
-         "next":11
-      },
-      "no":{  
-         "text":"No",
-         "next":10
-      }
+
+   "question9":{  
+      "questionText":"Was the case terminated before charging by the prosectution (no papered)?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"question11"
+         },
+         {  
+            "answerText":"No",
+            "next":"question10"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Has it been 4 years since you were \"off papers\" for the felony non-conviction?",
-      "yes":{  
-         "text":"Yes",
-         "next":"eligable"
-      },
-      "no":{  
-         "text":"No",
-         "next":"ineligible at this time"
-      }
+
+   "question10":{  
+      "questionText":"Has it been 4 years since you were \"off papers\" for the felony non-conviction?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"eligible"
+         },
+         {  
+            "answerText":"No",
+            "next":"ineligible at this time"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Has it been 3 years since you were \"off papers\" for the felony non-conviction?",
-      "yes":{  
-         "text":"Yes",
-         "next":"eligable"
-      },
-      "no":{  
-         "text":"No",
-         "next":"ineligible at this time"
-      }
+
+   "question11":{  
+      "questionText":"Has it been 3 years since you were \"off papers\" for the felony non-conviction?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"eligible"
+         },
+         {  
+            "answerText":"No",
+            "next":"ineligible at this time"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Has it been two years since you were \"off papers\" for the misdemeanor non-conviction?",
-      "yes":{  
-         "text":"Yes",
-         "next":"eligable"
-      },
-      "no":{  
-         "text":"No",
-         "next":"ineligible at this time"
-      }
+
+   "question12":{  
+      "questionText":"Has it been two years since you were \"off papers\" for the misdemeanor non-conviction?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"eligible"
+         },
+         {  
+            "answerText":"No",
+            "next":"ineligible at this time"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Is the ineligible conviction for a felony or misdemeanor?",
-      "yes":{  
-         "text":"Felony",
-         "next":14
-      },
-      "no":{  
-         "text":"Misdemeanor",
-         "next":15
-      }
+
+   "question13":{  
+      "questionText":"Is the ineligible conviction for a felony or misdemeanor?",
+      "answers":[  
+         {  
+            "answerText":"Felony",
+            "next":"question14"
+         },
+         {  
+            "answerText":"Misdemeanor",
+            "next":"question15"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Has it been 10 years since you were \"off papers\" for the misdemeanor conviction?",
-      "yes":{  
-         "text":"Yes",
-         "next":8
-      },
-      "no":{  
-         "text":"No",
-         "next":"ineligible at this time"
-      }
+
+   "question14":{  
+      "questionText":"Has it been 10 years since you were \"off papers\" for the misdemeanor conviction?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"question8"
+         },
+         {  
+            "answerText":"No",
+            "next":"ineligible at this time"
+         }
+      ],
+      "helperText":[  
+
+      ]
    },
-   {  
-      "question":"Has it been 5 years since you were \"off papers\" for the misdemeanor conviction?",
-      "yes":{  
-         "text":"Yes",
-         "next":8
-      },
-      "no":{  
-         "text":"No",
-         "next":"ineligible at this time"
-      }
+   
+   "question15":{  
+      "questionText":"Has it been 5 years since you were \"off papers\" for the misdemeanor conviction?",
+      "answers":[  
+         {  
+            "answerText":"Yes",
+            "next":"question8"
+         },
+         {  
+            "answerText":"No",
+            "next":"ineligible at this time"
+         }
+      ],
+      "helperText":[  
+
+      ]
    }
-]
+}

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -1,4 +1,12 @@
 {  
+   "start":"question0",
+
+   "endStates":[
+      "eligible",
+      "ineligible",
+      "ineligible at this time"
+   ],
+
    "question0":{  
       "questionText":"Do you have a case pending?",
       "answers":[  

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -55,7 +55,8 @@
       ],
       "helperText":[  
 
-      ]
+      ],
+      "showIneligibleMisdemeanors":"true"
    },
 
    "question3":{  
@@ -157,7 +158,8 @@
       ],
       "helperText":[  
 
-      ]
+      ],
+      "showIneligibleMisdemeanors":"true"
    },
 
    "question9":{  

--- a/js/app.js
+++ b/js/app.js
@@ -1,200 +1,4 @@
 'use strict';
-/*
-ELIGIBILITY_FLOW contains questions text and links to the next question or eligibility state
-
-ELIGIBILITY_FLOW FORMAT EXAMPLE
-questions are numbered by their position in the array, currently from 0-15 for a total of 16 questions
-{   // Question # 
-    question: "this text will be displayed as the question",
-    yes: {
-        text: "This text will be displayed on the 'yes' button",
-        next: # or eligibility (if clicked, this answer leads to this question # or eligibility)
-    },
-    no: {
-        text: "This text will be displayed on the 'no' button",
-        next: # or eligibility (if clicked, this answer leads to this question # or eligibility)
-    }
-}
-*/
-var ELIGIBILITY_FLOW = [
-    {   // Question 0
-        question: "Do you have a case pending?",
-        yes: {
-            text: "Yes",
-            next: "ineligible at this time"
-        },
-        no: {
-            text: "No",
-            next: 1
-        }
-    },
-    {   // Question 1
-        question: "Are you sealing a conviction or a non-conviction?",
-        yes: {
-            text: "Conviction",
-            next: 2
-        },
-        no: {
-            text: "Non-conviction",
-            next: 5
-        }
-    },
-    {   // Question 2
-        question: "Is this an eligible misdemeanor/felony or an ineligible misdemeanor/felony?",
-        yes: {
-            text: "Eligible misdemeanor or felony",
-            next: 3
-        }, 
-        no: {
-            text: "Ineligible misdemeanor or felony",
-            next: "ineligible"
-        }
-    },
-    {   // Question 3
-        question: "Have you subsequently been convicted of another crime in any jurisdiction?",
-        yes: {
-            text: "Yes",
-            next: "ineligible"
-        },
-        no: {
-            text: "No",
-            next: 4
-        }
-    },
-    {   // Question 4
-        question: "Has it been 8 years since you were off papers?",
-        yes: {
-            text: "Yes",
-            next: "eligable"
-        },
-        no: {
-            text: "No",
-            next: "ineligible at this time"
-        }
-    },
-    {   // Question 5
-        question: "Is your non-conviction the result of a Deferred Sentencing Agreement?",
-        yes: {
-            text: "Yes",
-            next: 7
-        },
-        no: {
-            text: "No",
-            next: 6
-        }
-    },
-    {   // Question 6
-        question: "Do you also have an ineligible conviction on your record?",
-        yes: {
-            text: "Yes",
-            next: 13
-        },
-        no: {
-            text: "No",
-            next: 8
-        }
-    },
-    {   // Question 7
-        question: "Do you also have an ineligible conviction on your record?",
-        yes: {
-            text: "Yes",
-            next: "ineligible"
-        },
-        no: {
-            text: "No",
-            next: 8
-        }
-    },
-    {   // Question 8
-        question: "Is the non-conviction for an eligible misdemeanor or an ineligible misdemeanor/felony?",
-        yes: {
-            text: "Eligible misdemeanor/felony",
-            next: 12 
-        },
-        no: {
-            text: "Ineligible misdemeanor/felony",
-            next: 9
-        }
-    },
-    {   // Question 9
-        question: "Was the case terminated before charging by the prosectution (no papered)?",
-        yes: {
-            text: "Yes",
-            next: 11
-        },
-        no: {
-            text: "No",
-            next: 10
-        }
-    },
-    {   // Question 10
-        question: "Has it been 4 years since you were \"off papers\" for the felony non-conviction?",
-        yes: {
-            text: "Yes",
-            next: "eligable"
-        },
-        no: {
-            text: "No",
-            next: "ineligible at this time"
-        }
-    },
-    {   // Question 11
-        question: "Has it been 3 years since you were \"off papers\" for the felony non-conviction?",
-        yes: {
-            text: "Yes",
-            next: "eligable"
-        },
-        no: {
-            text: "No",
-            next: "ineligible at this time" 
-        }
-    },
-    {   // Question 12
-        question: "Has it been two years since you were \"off papers\" for the misdemeanor non-conviction?",
-        yes: {
-            text: "Yes",
-            next: "eligable"
-        },
-        no: {
-            text: "No",
-            next: "ineligible at this time" 
-        }
-    },
-    {   // Question 13
-        question: "Is the ineligible conviction for a felony or misdemeanor?",
-        yes: {
-            text: "Felony",
-            next: 14 
-        },
-        no: {
-            text: "Misdemeanor",
-            next: 15
-        }
-    },
-    {   // Question 14
-        question: "Has it been 10 years since you were \"off papers\" for the misdemeanor conviction?",
-        yes: {
-            text: "Yes",
-            next: 8
-        },
-        no: {
-            text: "No",
-            next: "ineligible at this time" 
-        }
-    },
-    {   // Question 15
-        question: "Has it been 5 years since you were \"off papers\" for the misdemeanor conviction?",
-        yes: {
-            text: "Yes",
-            next: 8 
-        },
-        no: {
-            text: "No",
-            next: "ineligible at this time"
-        }
-    },
-];
-
 
 // App definition + dependencies
 var myApp = angular.module('myApp', [
@@ -273,12 +77,19 @@ myApp.controller('EligibilityWizardController', function($http) {
     // history holds the user's answers to previous questions to be returned when eligibility is known
     self.history = [];
 
+    // Grab the eligibility flow from a static JSON file stored at the root of the project
+    // This is synchronous because it is needed to display the initial question to the user
+    // if it is made asynchronous, strange values flash on the screen before initial values are shown
+    var req = new XMLHttpRequest();
+    req.open("GET", "eligibility-flow.json", false);
+    req.send(null);
+    var ELIGIBILITY_FLOW = JSON.parse(req.responseText);
+
     // Grab the ineligible misdemeanors from a static JSON file stored at the root of the project
     $http.get('ineligible-misdemeanors.json')
     .success(function(data, status, headers, config) {
         // if the app successfully gets misdemeanor data from the JSON file, assign it to self.ineligibleMisdemeanors for use in the wizard
         self.ineligibleMisdemeanors = data;
-        console.log(self.ineligibleMisdemeanors);
     });
 
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,15 @@
 'use strict';
 
+// Grab the eligibility flow from a static JSON file stored at the root of the project
+var ELIGIBILITY_FLOW;
+
+var req = new XMLHttpRequest();
+req.open("GET", "eligibility-flow.json", true);
+req.addEventListener("load", function() {
+    ELIGIBILITY_FLOW = JSON.parse(req.responseText);
+});
+req.send(null);
+
 // App definition + dependencies
 var myApp = angular.module('myApp', [
     // necessary for matching the URL to an available resource
@@ -76,14 +86,6 @@ myApp.controller('EligibilityWizardController', function($http) {
     self.currentStep = 0;
     // history holds the user's answers to previous questions to be returned when eligibility is known
     self.history = [];
-
-    // Grab the eligibility flow from a static JSON file stored at the root of the project
-    // This is synchronous because it is needed to display the initial question to the user
-    // if it is made asynchronous, strange values flash on the screen before initial values are shown
-    var req = new XMLHttpRequest();
-    req.open("GET", "eligibility-flow.json", false);
-    req.send(null);
-    var ELIGIBILITY_FLOW = JSON.parse(req.responseText);
 
     // Grab the ineligible misdemeanors from a static JSON file stored at the root of the project
     $http.get('ineligible-misdemeanors.json')

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -34,14 +34,17 @@
             </ul> 
         </div> <!-- end of list of ineligible misdemeanors -->
 
-
-        <md-button ng-click="eligibilityCtrl.submitYes()" class="md-raised md-primary md-button md-default-theme">{{eligibilityCtrl.yesText()}}</md-button>
-        <md-button ng-click="eligibilityCtrl.submitNo()" class="md-raised md-primary md-button md-default-theme">{{eligibilityCtrl.noText()}}</md-button>
+        <!-- Show buttons for all possible answers to this question -->
+        <span ng-repeat="answer in eligibilityCtrl.currentQuestion.answers">
+            <md-button ng-click="eligibilityCtrl.submitAnswer($index)" class="md-raised md-primary md-button md-default-theme" >
+                {{answer.answerText}}</md-button>
+        </span> <!-- end of answer section -->
+        
       </div> <!-- end of question section -->
 
       <!-- This section only shows if the user has reached an eligibilty state -->
-      <div ng-show="eligibilityCtrl.eligibilityKnown()">
-        <h3>This offense is {{eligibilityCtrl.currentStep}} for expungement.</h3>
+      <div ng-show="eligibilityCtrl.eligibilityKnown">
+        <h3>This offense is {{eligibilityCtrl.eligibility}} for expungement.</h3>
 
         <!-- This section shows a history of all of the questions and answers -->
         <div ng-repeat="record in eligibilityCtrl.history">

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -6,11 +6,11 @@
       <h1>Eligibility Checker</h1> 
       
       <!-- Questions. This section only shows if the user has not reached an eligibilty state -->
-      <div ng-show="!eligibilityCtrl.eligibilityKnown()">
-        <p>{{eligibilityCtrl.currentQuestion()}}</p>
+      <div ng-show="!eligibilityCtrl.eligibilityKnown">
+        <p>{{eligibilityCtrl.currentQuestion.questionText}}</p>
 
-        <!-- Show ineligible misdemeanors on step 2 & 8-->
-        <div ng-show="eligibilityCtrl.currentStep == 2 || eligibilityCtrl.currentStep == 8 ">
+        <!-- Show ineligible misdemeanors on steps with special property "showIneligibleMisdemeanors"-->
+        <div ng-show="eligibilityCtrl.currentQuestion.showIneligibleMisdemeanors == true">
             <h3>Ineligible felony</h3>
             <p>
               "Ineligible felony" means any felony other than a failure to appear 

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -39,6 +39,11 @@
             <md-button ng-click="eligibilityCtrl.submitAnswer($index)" class="md-raised md-primary md-button md-default-theme" >
                 {{answer.answerText}}</md-button>
         </span> <!-- end of answer section -->
+
+        <!-- If there is helper text for the question, show it here (ie explanations of legalese) -->
+        <div ng-show="eligibilityCtrl.currentQuestion.helperText.length > 0" ng-repeat="text in eligibilityCtrl.currentQuestion.helperText">
+            <p>{{text}}</p>
+        </div> <!-- end of helper text section -->
         
       </div> <!-- end of question section -->
 


### PR DESCRIPTION
I created a separate json file named eligibility-flow.json which anyone can change to edit the question text or answer text.  

I tried to make the format flexible.  Right now, all the questions have only two answers, but now it would be easy to add multiple answers if the need arises later on.  I've also left space for "helperText" where we can add definitions to explain the legal terms.  

(Everything still looks the same, so I am not adding a screenshot.  This just changed the functionality.)
