### PR TITLE
End state abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is an endState object:
         }
 ```
 `"eligiblityText"` = text that will be displayed for the user as a header when they reach this state
-`"icon"` = name of a [Bootstrap glyphicon](http://getbootstrap.com/components/#glyphicons) to be displayed on results page
+`"icon"` = name of a [Bootstrap glyphicon](http://getbootstrap.com/components/#glyphicons) to be displayed on results page.  If no icon is desired, this can be an empty string `"icon":"",`.
 `"helperText"` = extra text with suggestions for what to do next
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The file is made up of three special categories: `"start"`, `"endStates"`, and `
 
 2. `"endStates":`: endStates is a dictionary of endState objects
 
+3. `"questions":` questions is a dictionary of question objects
+
 This is an endState object:
 ```
 "eligible":{
@@ -63,7 +65,6 @@ This is an endState object:
 `"helperText"` = extra text with suggestions for what to do next
 
 
-3. `"questions":` questions is a dictionary of question objects
 
 This is a question object:
 ```

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ This is a question object:
     "answers":[
        {
           "answerText":"Yes",
-          "next":"ineligible at this time"
+          "next":"ineligible-at-this-time"
        },
        {
           "answerText":"No",
-          "next":"question1"
+          "next":"1"
        }
     ],
     "helperText":[

--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ This is an endState object:
 ```
 "eligible":{
         "eligiblityText":"This offense is likely eligible for expungement.",
+        "icon":"glyphicon glyphicon-ok-circle",
         "helperText":"...this is what you should do next in this case..."
         }
 ```
 `"eligiblityText"` = text that will be displayed for the user as a header when they reach this state
+`"icon"` = name of a [Bootstrap glyphicon](http://getbootstrap.com/components/#glyphicons) to be displayed on results page
 `"helperText"` = extra text with suggestions for what to do next
 
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,55 @@
 # [expungement-dc](http://codefordc.github.io/expungement-dc/#/)
-A simple website for people trying to navigate the process of having records sealed in DC
+
+A simple website for people trying to navigate [the process of having records sealed](https://en.wikipedia.org/wiki/Expungement)
+in DC.
 
 * As a returning citizen I want to easily and quickly find out if my records are eligible for sealing.
 * As a returning citizen, I want step by step information on how to obtain my criminal records in DC.
 * As a returning citizen I want to understand my rights in the records sealing process.
 * As a returning citizen I want help connecting to legal services for help sealing my record.
 * As a returning citizen I want help connecting to other services for returning citizens such as job placement and training.
-* As a returning ciizen I want to advocate for progress on issues facing people like me.
-
+* As a returning citizen I want to advocate for progress on issues facing people like me.
 * As a legal services provider, I want to have access to forms to assist my client in filing a motion for sealing.
-
 * As an attorney, I want to look up whether an offense is eligible for sealing in DC.
 * As an attorney, I want to be able to help a returning citizen breakdown the timeline for sealing eligibility using a chart
 
 ---
+
 Additional resources:
 
 - [Flowchart](docs/flowchart.jpeg)
 - Requirements ([1](docs/requirements_1.jpeg) & [2](docs/requirements_1.jpeg))
 
 ---
-###eligibility-flow.json
-[eligibility-flow.json](eligibility-flow.json) contains the questions, answers, and flow logic 
-for the wizard which guides users through an eligibility check. 
+
+## Development
+
+First, make sure that you have [`git`](http://git-scm.com/downloads) on your computer.
+Create your own [fork](https://guides.github.com/activities/forking/) of the repository, then clone it to your computer:
+
+```sh
+$ git clone git@github.com:[YOUR GITHUB NAME]/expungement-dc.git
+```
+
+You can work on the `master` branch (which is the default), but it's preferable
+to set up a new branch if you're working on a specific feature:
+
+```sh
+$ git checkout -b [NEW BRANCH NAME]
+```
+
+---
+
+### eligibility-flow.json
+
+[eligibility-flow.json](eligibility-flow.json) contains the questions, answers, and flow logic
+for the wizard which guides users through an eligibility check.
 
 
 The file starts with two special properties:
 
-1. `"start":"question0"`
-start indicates what the initial question should be
-
-2. `"endStates":["eligible", "ineligible", "ineligible at this time"]`
-endStates is an array of the possible end states in the flow chart
+1. `"start":"question0"`: start indicates what the initial question should be
+2. `"endStates":["eligible", "ineligible", "ineligible at this time"]`: endStates is an array of the possible end states in the flow chart
 
 The remainder of the file is made up of the individual numbered objects contained inside of a parent questions object:
 
@@ -58,9 +76,9 @@ questions: {
 
 
 
-`"questionText"` = question that will be displayed for the user 
+`"questionText"` = question that will be displayed for the user
 
-`"answers"` = an array of answer objects.  Each answer object should have `"answerText"` and `"next"`. This example has two possible answers to the question, but there can be as many as needed. 
+`"answers"` = an array of answer objects.  Each answer object should have `"answerText"` and `"next"`. This example has two possible answers to the question, but there can be as many as needed.
 
 `"answerText"` = words that will be displayed on the buttons
 
@@ -71,17 +89,7 @@ questions: {
 note: If you need to use quotation marks, the character must be 'escaped' with a backslash.  For example, the quotation marks around "Pending" in `helperText` are escaped like this: `\"Pending\"`
 
 ---
-Developement guide:
 
-    First, make sure that you have [`git`](http://git-scm.com/downloads) on your computer. Create your own [fork](https://guides.github.com/activities/forking/) of the repository, then clone it to your computer:
-
-    git clone git@github.com:[YOUR GITHUB NAME]/expungement-dc.git
-
-	You can work on the `master` branch (which is the default), but it's preferable to set up a new branch if you're working on a specific feature:
-
-    git checkout -b [NEW BRANCH NAME]
-
----
 To Do:
 
 - Add Ineligible Felonies to Step #6 of the wizard

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ for the wizard which guides users through an eligibility check.
 
 The file is made up of three special categories: `"start"`, `"endStates"`, and `"questions"`:
 
-1. `"start":"question0"`: string indicating what the initial question should be (must match a question name)
+1. `"start":"0"`: string indicating what the initial question should be (must match a question name)
 
 2. `"endStates":`: endStates is a dictionary of endState objects
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The file is made up of three special categories: `"start"`, `"endStates"`, and `
 
 3. `"questions":{}` questions is a dictionary of question objects
 
-This is an endState object:
+This is an **endState object**:
 ```
 "eligible":{
         "eligiblityText":"This offense is likely eligible for expungement.",
@@ -68,9 +68,7 @@ This is an endState object:
 
 `"helperText"` = extra text with suggestions for what to do next
 
-
-
-This is a question object:
+This is a **question object**:
 ```
 "0":{
     "questionText":"Do you have a case pending?",

--- a/README.md
+++ b/README.md
@@ -46,35 +46,44 @@ $ git checkout -b [NEW BRANCH NAME]
 for the wizard which guides users through an eligibility check.
 
 
-The file starts with two special properties:
+The file is made up of three special categories: `"start"`, `"endStates"`, and `"questions"`:
 
-1. `"start":"question0"`: start indicates what the initial question should be
-2. `"endStates":["eligible", "ineligible", "ineligible at this time"]`: endStates is an array of the possible end states in the flow chart
+1. `"start":"question0"`: string indicating what the initial question should be (must match a question name)
 
-The remainder of the file is made up of the individual numbered objects contained inside of a parent questions object:
+2. `"endStates":`: endStates is a dictionary of endState objects
 
+This is an endState object:
 ```
-questions: {
-  "0":{
-        "questionText":"Do you have a case pending?",
-        "answers":[
-           {
-              "answerText":"Yes",
-              "next":"ineligible at this time"
-           },
-           {
-              "answerText":"No",
-              "next":"question1"
-           }
-        ],
-        "helperText":[
-           "\"Pending\" refers to any case that is pending or has not been fully resolved. For example, if a case does not have a case disposition, it is likely a case pending."
-        ]
-     }
-}
+"eligible":{
+        "eligiblityText":"This offense is likely eligible for expungement.",
+        "helperText":"...this is what you should do next in this case..."
+        }
 ```
+`"eligiblityText"` = text that will be displayed for the user as a header when they reach this state
+`"helperText"` = extra text with suggestions for what to do next
 
 
+3. `"questions":` questions is a dictionary of question objects
+
+This is a question object:
+```
+"0":{
+    "questionText":"Do you have a case pending?",
+    "answers":[
+       {
+          "answerText":"Yes",
+          "next":"ineligible at this time"
+       },
+       {
+          "answerText":"No",
+          "next":"question1"
+       }
+    ],
+    "helperText":[
+       "\"Pending\" refers to any case that is pending or has not been fully resolved. For example, if a case does not have a case disposition, it is likely a case pending."
+    ]
+ }
+```
 
 `"questionText"` = question that will be displayed for the user
 
@@ -82,7 +91,7 @@ questions: {
 
 `"answerText"` = words that will be displayed on the buttons
 
-`"next"` = what should the user see next if they click this answer? must be the name of a question OR one of the options defined in endStates (see 2. above)
+`"next"` = what should the user see next if they click this answer? must be the name of a question OR the name of an endState object (see 2. above)
 
 `"helperText"` = definitions or explanations of legalese (this can be an empty: `"helperText":[]`)
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ for the wizard which guides users through an eligibility check.
 
 The file is made up of three special categories: `"start"`, `"endStates"`, and `"questions"`:
 
-1. `"start":"0"`: string indicating what the initial question should be (must match a question name)
+1. `"start":"0"` string indicating what the initial question should be (must match a question name)
 
-2. `"endStates":`: endStates is a dictionary of endState objects
+2. `"endStates":{}` endStates is a dictionary of endState objects
 
-3. `"questions":` questions is a dictionary of question objects
+3. `"questions":{}` questions is a dictionary of question objects
 
 This is an endState object:
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ This is an endState object:
         }
 ```
 `"eligiblityText"` = text that will be displayed for the user as a header when they reach this state
-`"icon"` = name of a [Bootstrap glyphicon](http://getbootstrap.com/components/#glyphicons) to be displayed on results page.  If no icon is desired, this can be an empty string `"icon":"",`.
+
+`"icon"` = name of a [Bootstrap glyphicon](http://getbootstrap.com/components/#glyphicons) to be displayed on results page.  If no icon is desired, this can be an empty string `"icon":""`
+
 `"helperText"` = extra text with suggestions for what to do next
 
 

--- a/css/app.css
+++ b/css/app.css
@@ -19,7 +19,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .container {
-    padding-top: 100px;   
+    padding-top: 100px;
     max-width: 1100px;
     margin: 0 auto;
     padding: 50px 15px;
@@ -37,7 +37,7 @@ h1, h2, h3, h4, h5, h6 {
     top: -5px;
     left: 0;
     right: 0;
-    z-index: 99;    
+    z-index: 99;
     height: 60px;
 }
 .titlebar-band {
@@ -85,9 +85,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 .titlebar-content {
     display: block;
-    max-width: 1100px; 
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 0 15px; 
+    padding: 0 15px;
 }
 
 .misdemeanors_group {
@@ -115,3 +115,32 @@ p.question-text {
 .progress-bar {
   background-color: rgb(63,81,181);
 }
+
+
+/* Tooltip using only CSS */
+
+button.tooltips {
+  cursor: pointer;
+}
+
+button[tooltip-text]:hover::after {
+  content: attr(tooltip-text);
+  position: absolute;
+  display: inline;
+  left: 50%;
+  top: 100%;
+  min-width: 140px;
+  border-top: 8px solid #000000;
+  border-right: 8px solid transparent;
+  border-left: 8px solid transparent;
+  border-radius: 6px;
+  background-color: #000000;
+  color: #FFFFFF;
+  margin-left: -8px;
+  z-index: 999;
+  opacity: 0.8;
+  margin-left: -76px;
+  margin-top: 3px;
+}
+
+/* end of tooltip */

--- a/css/app.css
+++ b/css/app.css
@@ -129,7 +129,7 @@ button[tooltip-text]:hover::after {
   display: inline;
   left: 50%;
   top: 100%;
-  min-width: 140px;
+  min-width: 50px;
   border-top: 8px solid #000000;
   border-right: 8px solid transparent;
   border-left: 8px solid transparent;
@@ -139,7 +139,7 @@ button[tooltip-text]:hover::after {
   margin-left: -8px;
   z-index: 999;
   opacity: 0.8;
-  margin-left: -76px;
+  margin-left: -25px;
   margin-top: 3px;
 }
 

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -1,283 +1,292 @@
-{  
+{
    "start":"0",
 
-   "endStates":[
-      "eligible",
-      "ineligible",
-      "ineligible-at-this-time"
-   ],
+   "endStates":{
+      "eligible":{
+        "eligiblityText":"This offense is likely eligible for expungement.",
+        "helperText":"...this is what you should do next in this case..."
+        },
+      "ineligible":{
+        "eligiblityText":"This offense is ineligible for expungement.",
+        "helperText":"...this is what you should do next in this case..."
+        },
+      "ineligible-at-this-time":{
+        "eligiblityText":"This offense is ineligible at this time for expungement.",
+        "helperText":"...this is what you should do next in this case..."
+      }
+   },
 
    "questions":{
-      "0":{  
+      "0":{
          "questionText":"Do you have a case pending?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"ineligible-at-this-time"
             },
-            {  
+            {
                "answerText":"No",
                "next":"1"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Pending\" refers to any case that is pending or has not been fully resolved. For example, if a case does not have a case disposition, it is likely a case pending."
          ]
       },
 
-      "1":{  
+      "1":{
          "questionText":"Are you sealing a conviction or a non-conviction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Conviction",
                "next":"2"
             },
-            {  
+            {
                "answerText":"Non-conviction",
                "next":"5"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Convicted\" refers to the judgment (sentence) on a verdict or a finding of guilty, a plea of guilty or a plea of nolo contendere, or a plea or verdict of not guilty by reason of insanity."
          ]
       },
 
-      "2":{  
+      "2":{
          "questionText":"Is this an eligible misdemeanor/felony or an ineligible misdemeanor/felony?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Eligible misdemeanor or felony",
                "next":"3"
             },
-            {  
+            {
                "answerText":"Ineligible misdemeanor or felony",
                "next":"ineligible"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ],
          "showIneligibleMisdemeanors":true
       },
 
-      "3":{  
+      "3":{
          "questionText":"Have you subsequently been convicted of another crime in any jurisdiction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"ineligible"
             },
-            {  
+            {
                "answerText":"No",
                "next":"4"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ]
       },
 
-      "4":{  
+      "4":{
          "questionText":"Has it been 8 years since you were off papers?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"eligible"
             },
-            {  
+            {
                "answerText":"No",
                "next":"ineligible-at-this-time"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
          ]
       },
 
-      "5":{  
+      "5":{
          "questionText":"Is your non-conviction the result of a Deferred Sentencing Agreement?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"7"
             },
-            {  
+            {
                "answerText":"No",
                "next":"6"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Deferred Sentencing Agreement\" means ..."
          ]
       },
 
-      "6":{  
+      "6":{
          "questionText":"Do you also have an ineligible conviction on your record?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"13"
             },
-            {  
+            {
                "answerText":"No",
                "next":"8"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ]
       },
 
-      "7":{  
+      "7":{
          "questionText":"Do you also have an ineligible conviction on your record?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"ineligible"
             },
-            {  
+            {
                "answerText":"No",
                "next":"8"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ]
       },
 
-      "8":{  
+      "8":{
          "questionText":"Is the non-conviction for an eligible misdemeanor or an ineligible misdemeanor/felony?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Eligible misdemeanor/felony",
                "next":"12"
             },
-            {  
+            {
                "answerText":"Ineligible misdemeanor/felony",
                "next":"9"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ],
          "showIneligibleMisdemeanors":true
       },
 
-      "9":{  
+      "9":{
          "questionText":"Was the case terminated before charging by the prosectution (no papered)?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"11"
             },
-            {  
+            {
                "answerText":"No",
                "next":"10"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ]
       },
 
-      "10":{  
+      "10":{
          "questionText":"Has it been 4 years since you were \"off papers\" for the felony non-conviction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"eligible"
             },
-            {  
+            {
                "answerText":"No",
                "next":"ineligible-at-this-time"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
          ]
       },
 
-      "11":{  
+      "11":{
          "questionText":"Has it been 3 years since you were \"off papers\" for the felony non-conviction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"eligible"
             },
-            {  
+            {
                "answerText":"No",
                "next":"ineligible-at-this-time"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
          ]
       },
 
-      "12":{  
+      "12":{
          "questionText":"Has it been two years since you were \"off papers\" for the misdemeanor non-conviction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"eligible"
             },
-            {  
+            {
                "answerText":"No",
                "next":"ineligible-at-this-time"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
          ]
       },
 
-      "13":{  
+      "13":{
          "questionText":"Is the ineligible conviction for a felony or misdemeanor?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Felony",
                "next":"14"
             },
-            {  
+            {
                "answerText":"Misdemeanor",
                "next":"15"
             }
          ],
-         "helperText":[  
+         "helperText":[
 
          ]
       },
 
-      "14":{  
+      "14":{
          "questionText":"Has it been 10 years since you were \"off papers\" for the misdemeanor conviction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"8"
             },
-            {  
+            {
                "answerText":"No",
                "next":"ineligible-at-this-time"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
          ]
       },
-      
-      "15":{  
+
+      "15":{
          "questionText":"Has it been 5 years since you were \"off papers\" for the misdemeanor conviction?",
-         "answers":[  
-            {  
+         "answers":[
+            {
                "answerText":"Yes",
                "next":"8"
             },
-            {  
+            {
                "answerText":"No",
                "next":"ineligible-at-this-time"
             }
          ],
-         "helperText":[  
+         "helperText":[
             "\"Off papers\" means when a person has been unconditionally discharged from incarceration, commitment, probation, parole or supervised release – whichever is the latest."
          ]
       }

--- a/eligibility-flow.json
+++ b/eligibility-flow.json
@@ -4,14 +4,17 @@
    "endStates":{
       "eligible":{
         "eligiblityText":"This offense is likely eligible for expungement.",
+        "icon":"glyphicon glyphicon-ok-circle",
         "helperText":"...this is what you should do next in this case..."
         },
       "ineligible":{
         "eligiblityText":"This offense is ineligible for expungement.",
+        "icon":"glyphicon glyphicon-remove-circle",
         "helperText":"...this is what you should do next in this case..."
         },
       "ineligible-at-this-time":{
         "eligiblityText":"This offense is ineligible at this time for expungement.",
+        "icon":"glyphicon glyphicon-time",
         "helperText":"...this is what you should do next in this case..."
       }
    },

--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
             <div class="titlebar-content">
                 <div layout="row">
                     <div>
-                        <h3 class="pagetitle"><a href="#/">Clean Slate</a></h3> 
+                        <h3 class="pagetitle"><a href="#/">Clean Slate</a></h3>
                     </div>
                      <div class="menu">
-                       
+
                        <md-button ng-click="openLeftMenu()" hide-gt-sm>
                           <!-- menu link for mobile -->
                           Menu
@@ -60,11 +60,11 @@
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-aria.min.js"></script>
 
     <!-- also -->
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.21/angular-route.js"></script> 
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.21/angular-route.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.21/angular-resource.js"></script>
 
     <script src="//ajax.googleapis.com/ajax/libs/angular_material/0.8.3/angular-material.min.js"></script>
-    
+
     <!--<script src="js/vendor.js"></script>-->
     <script src="js/app.js"></script>
   </body>

--- a/js/app.js
+++ b/js/app.js
@@ -117,7 +117,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
                 case 'ineligible-at-this-time':
                     self.currentQuestion = self.params.questionNumber;
                     self.eligibilityKnown = true;
-                    //Convert url-friendly currrentQuestion into readable string
+                    //Convert url-friendly currentQuestion into readable string
                     self.eligibilityStatus = 'ineligible at this time';
                     self.userInput = userInput;
                     break;
@@ -138,6 +138,31 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
             // if the app successfully gets misdemeanor data from the JSON file, assign it to self.ineligibleMisdemeanors for use in the wizard
             self.ineligibleMisdemeanors = data;
         });
+
+        // go back one question
+        self.goBackOneQuestion = function() {
+            // if user is on the first question, simulate hitting the browser back button
+            console.log("currentQuestion = " + self.questionNumber);
+            if (self.questionNumber == self.eligibilityFlow.start) {
+                window.history.back()
+                return;
+            }
+
+            // remove last entry from userInput and previous question
+            userInput.pop();
+            var previousQuestion = answeredQuestions.pop();
+            console.log("going back to " + previousQuestion)
+            // go back to the previous question
+            $location.path('/eligibility-check/q/' + previousQuestion);
+        };
+
+        self.restart = function() {
+            // clear userInput and answeredQuestions
+            userInput = [];
+            answeredQuestions = [];
+            // jump back to the start of this flow
+            $location.path('/eligibility-check/q/' + self.eligibilityFlow.start);
+        };
 
         self.submitAnswer = function(answerIndex) {
 
@@ -185,6 +210,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
             }
             return progressPercent;
         };
+
     }
 
 

--- a/js/app.js
+++ b/js/app.js
@@ -90,6 +90,8 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
         self.eligibilityFlow = data;
         //Get the URL q parameter (the question name) from $routeParams
         self.params = $routeParams;
+        //Get the length of the eligibilityFlow object (this is only needed for progress bar estimation)
+        self.eligibilityFlowLength = Object.keys(self.eligibilityFlow.questions).length;
 
         // stateName is the name of the endState object or question object
         // (note: self.currentState points to the actual object)
@@ -118,7 +120,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
         // go back one question
         self.goBackOneQuestion = function() {
             // if user is on the first question, simulate hitting the browser back button
-            if (self.questionNumber == self.eligibilityFlow.start) {
+            if (self.stateName == self.eligibilityFlow.start) {
                 window.history.back()
                 return;
             }
@@ -179,21 +181,20 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
             throw new Error("There is no question or endState \'" + next + "\' in self.eligibilityFlow.");
         };
 
-        // progressBar depended on the fact that question names were numbers so this doesn't work at the moment
-        // I will fix it soon. -- JL
-        /*
+        // progressBar calculation
+        // TODO make this work even if the question names are not numbers
         self.progressBar = function() {
             var progressPercent = '';
             //If the current question isn't a number and is listed in the endStates array, then set the progess bar to 100
-            if(isNaN(self.currentQuestion) && self.eligibilityFlow.endStates.indexOf(self.currentQuestion) != -1){
+            if(isNaN(self.currentQuestion) && stateName in self.eligibilityFlow.endStates){
                 progressPercent = 100;
             } else {
                 //Otherwise, divide the current question number by the total number of question, multiply by 100, and round to get a nice percent
-                progressPercent = Math.round((self.questionNumber/self.eligibilityFlowLength) * 100);
+                progressPercent = Math.round((Number(stateName)/self.eligibilityFlowLength) * 100);
             }
             return progressPercent;
         };
-        */
+
 
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -81,9 +81,6 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
     var self = this; // self is equivalent to $scope
     self.eligibilityKnown = false;
 
-    // once eligibility is known, this will hold the final eligibility state
-    self.eligibility = null;
-
     // boolean indicating whether final state is known
     var executeController = function(data) {
         //Set self.eligibilityFlow to the data returned by the http request
@@ -125,6 +122,8 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
                 return;
             }
 
+            // if user is already on the results page
+            if ()
             // remove last entry from userInput and previous question
             userInput.pop();
             var previousQuestion = answeredQuestions.pop();

--- a/js/app.js
+++ b/js/app.js
@@ -90,7 +90,6 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
         self.eligibilityFlow = data;
         //Get the URL q parameter (the question name) from $routeParams
         self.params = $routeParams;
-        // the name of the current state (used to lookup question or endState object in eligibilityFlow)
         var stateName = self.params.stateName;
 
         // determine if this is a question or end state
@@ -179,7 +178,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
 
         // progressBar depended on the fact that question names were numbers so this doesn't work at the moment
         // I will fix it soon. -- JL
-
+        /*
         self.progressBar = function() {
             var progressPercent = '';
             //If the current question isn't a number and is listed in the endStates array, then set the progess bar to 100
@@ -191,7 +190,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
             }
             return progressPercent;
         };
-
+        */
 
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -90,6 +90,9 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
         self.eligibilityFlow = data;
         //Get the URL q parameter (the question name) from $routeParams
         self.params = $routeParams;
+
+        // stateName is the name of the endState object or question object
+        // (note: self.currentState points to the actual object)
         var stateName = self.params.stateName;
 
         // determine if this is a question or end state
@@ -141,7 +144,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
 
             // if this question was already answered, cleanup userInput before adding this answer to history
             if (answeredQuestions.indexOf(stateName) > -1) {
-                console.log("Could not find indexOf " + stateName + "Cleaning up question/answer history!")
+                console.log("Could not find indexOf " + stateName + " so Cleaning up question/answer history.")
                 var startDuplication = answeredQuestions.indexOf(stateName);
                 userInput.splice(startDuplication, userInput.length - startDuplication);
                 answeredQuestions.splice(startDuplication, answeredQuestions.length - startDuplication);

--- a/js/app.js
+++ b/js/app.js
@@ -90,6 +90,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
         self.eligibilityFlow = data;
         //Get the URL q parameter (the question name) from $routeParams
         self.params = $routeParams;
+        // the name of the current state (used to lookup question or endState object in eligibilityFlow)
         var stateName = self.params.stateName;
 
         // determine if this is a question or end state
@@ -178,7 +179,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
 
         // progressBar depended on the fact that question names were numbers so this doesn't work at the moment
         // I will fix it soon. -- JL
-        /*
+
         self.progressBar = function() {
             var progressPercent = '';
             //If the current question isn't a number and is listed in the endStates array, then set the progess bar to 100
@@ -190,7 +191,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
             }
             return progressPercent;
         };
-        */
+
 
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -172,7 +172,7 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
                 return;
             }
 
-            // else if there is no question cooresponding to currentQuestion
+            // else if there is no question corresponding to currentQuestion
             throw new Error("There is no question or endState \'" + next + "\' in self.eligibilityFlow.");
         };
 

--- a/js/app.js
+++ b/js/app.js
@@ -121,9 +121,9 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
                 window.history.back()
                 return;
             }
-
-            // if user is already on the results page
-            if ()
+            // if user is already on the results page and wants to go back
+            if (self.eligibilityKnown)
+                self.eligibilityKnown = false;
             // remove last entry from userInput and previous question
             userInput.pop();
             var previousQuestion = answeredQuestions.pop();

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -2,10 +2,32 @@
 
 <div class="row">
     <div class="col-md-12">
-      
-      <h1 class="text-center">Eligibility Checker</h1>
+
+        <!-- Header Row with nav buttons and title -->
+        <div class="row">
+            <div class="col-md-3 pull-left">
+            <h1>
+              <div class="btn-group" role="group" aria-label="nav buttons">
+                <button type="button" class="btn btn-default tooltips" tooltip-text="Previous Question">
+                    <span ng-click="eligibilityCtrl.goBackOneQuestion()" class="glyphicon glyphicon glyphicon-chevron-left" ></span>
+                </button>
+                <button type="button" class="btn btn-default tooltips" tooltip-text="Start Over">
+                    <span ng-click="eligibilityCtrl.restart()" class="glyphicon glyphicon glyphicon-repeat" ></span>
+                </button>
+              </div>
+            </div>
+            </h1>
+            <div class="col-md-6">
+                <h1 class="text-center">Eligibility Checker</h1>
+            </div>
+        </div>
+
+
+      <div class="button-"
+      <span ng-click="eligibilityCtrl.goBack()" class="glyphicon glyphicon glyphicon-chevron-left back-button" ></span>
+
       <hr>
-      
+
       <!-- Progress bar -->
       <div class="progress">
         <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar()}}%; min-width: 2em;">
@@ -22,7 +44,7 @@
             <div ng-show="eligibilityCtrl.currentQuestion.showIneligibleMisdemeanors == true">
                 <h3>Ineligible felony</h3>
                 <p>
-                  "Ineligible felony" means any felony other than a failure to appear 
+                  "Ineligible felony" means any felony other than a failure to appear
                   (§ 16-1327) [<a href="http://dccode.org/simple/sections/23-1327.html">§ 23‑1327</a>].
                 </p>
 
@@ -42,7 +64,7 @@
                       </span>
                     </li>
                   </div>
-                </ul> 
+                </ul>
             </div> <!-- end of list of ineligible misdemeanors -->
 
             <!-- If there is helper text for the question, show it here (ie explanations of legalese) -->
@@ -52,7 +74,7 @@
                 <p>{{text}}</p>
             </div> <!-- end of helper text section -->
           </div> <!-- end of question section -->
-  
+
           <div class="panel-footer">
             <!-- Show buttons for all possible answers to this question -->
             <span ng-repeat="answer in eligibilityCtrl.currentQuestion.answers">
@@ -73,7 +95,7 @@
             </h1>
             <h2>
               This offense is {{eligibilityCtrl.eligibilityStatus}} for expungement.
-            </h2>                      
+            </h2>
           </div>
         </div>
         <!-- User responses panel -->

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -28,13 +28,13 @@
 
       <hr>
 
-      <!-- Progress bar
+      <!-- Progress bar -->
       <div class="progress">
-        <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar}}%; min-width: 2em;">
+        <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar()}}%; min-width: 2em;">
           <span>{{eligibilityCtrl.progressBar()}}% Complete</span>
         </div>
       </div>
-  -->
+
 
       <!-- Questions: this section only shows if the user has not reached an eligibilty state -->
       <div ng-show="!eligibilityCtrl.eligibilityKnown">

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -28,20 +28,21 @@
 
       <hr>
 
-      <!-- Progress bar -->
+      <!-- Progress bar
       <div class="progress">
         <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar()}}%; min-width: 2em;">
           <span>{{eligibilityCtrl.progressBar()}}% Complete</span>
         </div>
       </div>
+        -->
       <!-- Questions: this section only shows if the user has not reached an eligibilty state -->
       <div ng-show="!eligibilityCtrl.eligibilityKnown">
         <div class="text-center panel panel-default">
           <div class="panel-body">
-            <p class="question-text">{{eligibilityCtrl.currentQuestion.questionText}}</p>
+            <p class="question-text">{{eligibilityCtrl.currentState.questionText}}</p>
 
-            <!-- Show ineligible misdemeanors on step 2 & 8-->
-            <div ng-show="eligibilityCtrl.currentQuestion.showIneligibleMisdemeanors == true">
+            <!-- Show ineligible misdemeanors on step 2 & 8 -->
+            <div ng-show="eligibilityCtrl.currentState.showIneligibleMisdemeanors == true">
                 <h3>Ineligible felony</h3>
                 <p>
                   "Ineligible felony" means any felony other than a failure to appear
@@ -68,7 +69,7 @@
             </div> <!-- end of list of ineligible misdemeanors -->
 
             <!-- If there is helper text for the question, show it here (ie explanations of legalese) -->
-            <div ng-show="eligibilityCtrl.currentQuestion.helperText.length > 0" ng-repeat="text in eligibilityCtrl.currentQuestion.helperText">
+            <div ng-show="eligibilityCtrl.currentState.helperText.length > 0" ng-repeat="text in eligibilityCtrl.currentState.helperText track by $index">
                 <hr>
                 <h1><span class="glyphicon glyphicon glyphicon-info-sign" aria-hidden="true"></span></h1>
                 <p>{{text}}</p>
@@ -77,25 +78,37 @@
 
           <div class="panel-footer">
             <!-- Show buttons for all possible answers to this question -->
-            <span ng-repeat="answer in eligibilityCtrl.currentQuestion.answers">
+            <span ng-repeat="answer in eligibilityCtrl.currentState.answers">
               <md-button ng-click="eligibilityCtrl.submitAnswer($index)" ng-href="#/eligibility-check/q/{{answer.next}}" class="md-raised md-primary md-button md-default-theme">{{answer.answerText}}</md-button>
             </span> <!-- end of answer section -->
           </div>
           </div>
         </div> <!-- end of question section -->
+
       <!-- This section only shows if the user has reached an eligibilty state -->
       <div ng-show="eligibilityCtrl.eligibilityKnown">
         <div class="panel panel-default">
           <div class="panel-body text-center">
+
+            <!-- Icons for different eligibility states
             <h1>
-              <!-- Icons for different eligibility states -->
               <span ng-show="eligibilityCtrl.currentQuestion === 'eligible'"class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span>
               <span ng-show="eligibilityCtrl.currentQuestion === 'ineligible-at-this-time'"class="glyphicon glyphicon-time" aria-hidden="true"></span>
               <span ng-show="eligibilityCtrl.currentQuestion === 'ineligible'"class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
             </h1>
+             -->
+
             <h2>
-              This offense is {{eligibilityCtrl.eligibilityStatus}} for expungement.
+              {{eligibilityCtrl.currentState.eligiblityText}}
             </h2>
+
+            <!-- If there is helper text for the endState, show it here (ie explanations of what to do next) -->
+            <div ng-show="eligibilityCtrl.currentState.helperText.length > 0">
+                <hr>
+                <h1><span class="glyphicon glyphicon glyphicon-info-sign" aria-hidden="true"></span></h1>
+                <p>{{eligibilityCtrl.currentState.helperText}}</p>
+            </div> <!-- end of helper text section -->
+
           </div>
         </div>
         <!-- User responses panel -->
@@ -113,15 +126,15 @@
               </div>
             </div>
           </div>
-          <!-- User responses list -->
+          <!-- User responses list (shows history of all questions and answers) -->
           <div class="panel-body">
             <div ng-repeat="record in eligibilityCtrl.userInput">
                 <h4></span><i>{{record.question}}</i></h4>
                 <p><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><b>{{record.answer}}</b></p>
             </div>
+
           </div>
         </div>
-        <!-- This section shows a history of all of the questions and answers -->
       </div> <!-- end of eligibility section -->
 
     </div><!-- /.col-md-12 -->

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -30,11 +30,12 @@
 
       <!-- Progress bar
       <div class="progress">
-        <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar()}}%; min-width: 2em;">
+        <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar}}%; min-width: 2em;">
           <span>{{eligibilityCtrl.progressBar()}}% Complete</span>
         </div>
       </div>
-        -->
+  -->
+
       <!-- Questions: this section only shows if the user has not reached an eligibilty state -->
       <div ng-show="!eligibilityCtrl.eligibilityKnown">
         <div class="text-center panel panel-default">
@@ -90,13 +91,10 @@
         <div class="panel panel-default">
           <div class="panel-body text-center">
 
-            <!-- Icons for different eligibility states
-            <h1>
-              <span ng-show="eligibilityCtrl.currentQuestion === 'eligible'"class="glyphicon glyphicon-ok-circle" aria-hidden="true"></span>
-              <span ng-show="eligibilityCtrl.currentQuestion === 'ineligible-at-this-time'"class="glyphicon glyphicon-time" aria-hidden="true"></span>
-              <span ng-show="eligibilityCtrl.currentQuestion === 'ineligible'"class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
+            <!-- Icons for eligibility state if present -->
+            <h1 ng-show="eligibilityCtrl.currentState.icon">
+              <span ng-class="eligibilityCtrl.currentState.icon" aria-hidden="true"></span>
             </h1>
-             -->
 
             <h2>
               {{eligibilityCtrl.currentState.eligiblityText}}

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -8,7 +8,7 @@
             <div class="col-md-3 pull-left">
             <h1>
               <div class="btn-group" role="group" aria-label="nav buttons">
-                <button type="button" class="btn btn-default tooltips" tooltip-text="Previous Question">
+                <button type="button" class="btn btn-default tooltips" tooltip-text="Back">
                     <span ng-click="eligibilityCtrl.goBackOneQuestion()" class="glyphicon glyphicon glyphicon-chevron-left" ></span>
                 </button>
                 <button type="button" class="btn btn-default tooltips" tooltip-text="Start Over">


### PR DESCRIPTION
Updated format for json end states to allow for many endstates.  From the new README, this is how endStates should be formatted:

This is an endState object:

```
"eligible":{
        "eligiblityText":"This offense is likely eligible for expungement.",
        "helperText":"...this is what you should do next in this case..."
        }
```

And this is how it would look:
![screen shot 2015-05-14 at 11 30 55 am](https://cloud.githubusercontent.com/assets/7838603/7635064/c498aeaa-fa2c-11e4-8dd9-69389dae8f12.png)

So if you want a different message for a certain endState, just make a new endState. 

This involved changing quite a bit of the `EligibilityWizardController` because before the endState names were hardwired in, and it depended on question names being numbers.   Now any valid string should work as a question or endState name. 
