### PR TITLE
Progress bar fix

### DIFF
--- a/combined-flow.json
+++ b/combined-flow.json
@@ -171,7 +171,7 @@
             },
             {
                "answerText":"No",
-               "next":"IneligibleFJ"
+               "next":"ineligibleFJ"
             }
          ],
          "helperText":[
@@ -253,7 +253,7 @@
             },
             {
                "answerText":"No",
-               "next":"IneligibleAI"
+               "next":"ineligibleAI"
             }
          ],
          "helperText":[

--- a/js/app.js
+++ b/js/app.js
@@ -105,8 +105,8 @@ function findTreeHeight(flow, state) {
     q.treeHeight = 1 + q.answers.reduce(function(maxHeight, answer) {
         // if answer.next is is an end state, height = 2
         if (answer.next in flow.endStates) {
-            if (maxHeight < 2)
-                return 2;
+            if (maxHeight < 1)
+                return 1;
             return maxHeight;
         }
         var nextHeight = flow.questions[answer.next].treeHeight;
@@ -127,9 +127,6 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
         self.eligibilityFlow = data;
         //Calculate height for each state
         findTreeHeight(self.eligibilityFlow, self.eligibilityFlow.start);
-        console.log("Found tree height!");
-        console.log(self.eligibilityFlow);
-
 
         //Get the URL q parameter (the question name) from $routeParams
         self.params = $routeParams;
@@ -237,7 +234,8 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
             } else {
                 // Otherwise, divide the number of questions answered by the tree height at this state
                 // multiply by 100, and round
-                progressPercent = Math.round((userInput.length/self.currentState.treeHeight) * 100);
+                var answered = answeredQuestions.length;
+                progressPercent = Math.round((answered/(answered + self.currentState.treeHeight - 1)) * 100);
             }
             return progressPercent;
         };

--- a/js/app.js
+++ b/js/app.js
@@ -101,7 +101,6 @@ function findTreeHeight(flow, state) {
     });
 
     // after recursive call, assign treeHeight to this state
-    var maxHeight = 0;
     q.treeHeight = 1 + q.answers.reduce(function(maxHeight, answer) {
         // if answer.next is is an end state, height = 2
         if (answer.next in flow.endStates) {

--- a/js/app.js
+++ b/js/app.js
@@ -71,6 +71,11 @@ myApp.controller('legalAidController',
         }
 ]);
 
+
+/***************************************************************
+VARIABLES AND FUNCTIONS USED IN EligibilityWizardController
+***************************************************************/
+
 //Keep userInput outside controller scope so that it isn't reset when $location changes
 var userInput = [];
 // questions in the order they were answered
@@ -80,7 +85,7 @@ var answeredQuestions = [];
 // function that assigns state.treeHeight to each state
 // bottom of the tree (end states) have a height of 1
 function findTreeHeight(flow, state) {
-    console.log("state = " + state);
+
     // if this is an end state
     if (state in flow.endStates) {
         flow.endStates[state].treeHeight = 1;
@@ -223,16 +228,16 @@ myApp.controller('EligibilityWizardController', function($http, $routeParams, $l
 
         };
 
-        // progressBar calculation
-        // TODO make this work even if the question names are not numbers
+        // progressBar calculation using treeHeight
         self.progressBar = function() {
             var progressPercent = '';
-            //If the current question isn't a number and is listed in the endStates array, then set the progess bar to 100
-            if(isNaN(self.currentQuestion) && stateName in self.eligibilityFlow.endStates){
+            //If the current question is an EndState, then set the progess bar to 100
+            if(stateName in self.eligibilityFlow.endStates){
                 progressPercent = 100;
             } else {
-                //Otherwise, divide the current question number by the total number of question, multiply by 100, and round to get a nice percent
-                progressPercent = Math.round((Number(stateName)/self.eligibilityFlowLength) * 100);
+                // Otherwise, divide the number of questions answered by the tree height at this state
+                // multiply by 100, and round
+                progressPercent = Math.round((userInput.length/self.currentState.treeHeight) * 100);
             }
             return progressPercent;
         };

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -25,13 +25,16 @@
 
       <hr>
 
-      <!-- PROGRESS BAR REMOVED FOR NOW, DOES NOT WORK WITH COMBINED JSON -->
-      <!-- Progress bar
-      <div class="progress">
-        <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar()}}%; min-width: 2em;">
-          <span>{{eligibilityCtrl.progressBar()}}% Complete</span>
-        </div>
-      </div> -->
+      <div class="row">
+            <div class="col-md-12 ">
+                <!-- Progress bar -->
+                <div class="progress">
+                  <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: {{eligibilityCtrl.progressBar()}}%; min-width: 2em;">
+                    <span>{{eligibilityCtrl.progressBar()}}% Complete</span>
+                  </div>
+                </div> 
+          </div>
+      </div>
 
 
       <!-- Questions: this section only shows if the user has not reached an eligibilty state -->


### PR DESCRIPTION
Fixed the progress bar.

For each question, I calculate the max number of questions (tree height) that the user might still have to answer.

Progress Bar no longer depends on the state names being numbers.  
