### PR TITLE
Fix nav buttons on mobile and desktop

### DIFF
--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -5,7 +5,7 @@
 
         <!-- Header Row with nav buttons and title -->
         <div class="row">
-            <div class="col-md-3 pull-left">
+            <div class="col-xs-3 col-md-3 pull-left">
                 <h1>
                   <div class="btn-group" role="group" aria-label="nav buttons">
                     <button type="button" ng-click="eligibilityCtrl.goBackOneQuestion()" class="btn btn-default tooltips" tooltip-text="Back">
@@ -17,7 +17,7 @@
                   </div>
                 </div>
                 </h1>
-                <div class="col-md-6">
+                <div class="col-xs-9 col-md-6">
                     <h1 class="text-center">Eligibility Checker</h1>
                 </div>
             </div>

--- a/views/eligibility-checker.html
+++ b/views/eligibility-checker.html
@@ -8,11 +8,11 @@
             <div class="col-md-3 pull-left">
                 <h1>
                   <div class="btn-group" role="group" aria-label="nav buttons">
-                    <button type="button" class="btn btn-default tooltips" tooltip-text="Back">
-                        <span ng-click="eligibilityCtrl.goBackOneQuestion()" class="glyphicon glyphicon glyphicon-chevron-left" ></span>
+                    <button type="button" ng-click="eligibilityCtrl.goBackOneQuestion()" class="btn btn-default tooltips" tooltip-text="Back">
+                        <span class="glyphicon glyphicon glyphicon-chevron-left" ></span>
                     </button>
-                    <button type="button" class="btn btn-default tooltips" tooltip-text="Restart">
-                        <span ng-click="eligibilityCtrl.restart()" class="glyphicon glyphicon glyphicon-repeat" ></span>
+                    <button type="button" ng-click="eligibilityCtrl.restart()" class="btn btn-default tooltips" tooltip-text="Restart">
+                        <span class="glyphicon glyphicon glyphicon-repeat" ></span>
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #50

**Two issues present:**
1. On tablet and desktop, imprecise clicks on nav buttons (i.e.: near the edge) didn't trigger navigation
2. Nav buttons weren't working on mobile phones (very small screens)

**Solutions:**
1. Move `ng-click` event handlers/attributes from `span` tags inside the buttons to the buttons themselves
2. Add `col-xs-#` classes to the containers for the header and the nav buttons to prevent overlap on extra-small viewports (mobile phone screens)

**Still Needed**
- Adjustment to the layout so the buttons group together on mobile
- Clean-up/review of the views markup 
