### PR TITLE
Fixed typo in routes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -39,7 +39,7 @@ myApp.config(['$routeProvider',
             })
             // Page for acquiring records in person
             .when('/acquire-inperson', {
-                templateUrl: 'view/acquire-inperson.html',
+                templateUrl: 'views/acquire-inperson.html',
                 controller: 'acquireInPersonController'
             })
             // Definitions


### PR DESCRIPTION
Fixes #82. I missed the 's' in the name of the views directory in my haste to write the patch.
