### PR TITLE
prefer https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[clean-slate](http://codefordc.github.io/clean-slate/)
+#[clean-slate](https://codefordc.github.io/clean-slate/)
 
 A simple website for people trying to navigate [the process of having records sealed](https://en.wikipedia.org/wiki/Expungement)
 in DC.


### PR DESCRIPTION
Using https will help [keep user information confidential](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/) from any prying eyes, which is especially important on a site like this. If there are any other places in the repo that link back to the site and specify the protocol, please let me know and I'll add it to this pull request.

In addition, please make sure to use the `https` link when linking to the site elsewhere. If the protocol is not specify, GitHub will default to https, so this only matters if you are typing out the full URI.
