### PR TITLE
fix broken link in README to combined-flow.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ git checkout -b [NEW BRANCH NAME]
 
 ### combined-flow.json
 
-[combined-flow.json](combined-flow.json) contains the questions, answers, and flow logic
+[combined-flow.json](data/combined-flow.json) contains the questions, answers, and flow logic
 for the wizard which guides users through an eligibility check.
 
 The file is made up of three special categories: `"start"`, `"endStates"`, and `"questions"`:


### PR DESCRIPTION
Just noticed that the link to combined-flow.json wasn't updated when the file structure changed, so I fixed it.
