### PR TITLE
Add ReadClearly

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
               content="user-scalable=no, width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
         <title>Clean Slate DC</title>
         <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-        <!--<link rel="stylesheet" href="css/bootstrap.min.css">
-        <!--<link rel="stylesheet" href="css/bootstrap.min.css">-->
+        <link rel="stylesheet" href="css/bootstrap.min.css">
+        <link rel="stylesheet" href="css/bootstrap.min.css">
         <link rel="stylesheet" href="css/bootstrap-superhero.min.css">
         <link rel="stylesheet" href="css/app.css">
         <link rel="canonical" href="https://cleanslatedc.com">
@@ -46,15 +46,16 @@
 
         <!-- Dependencies -->
         <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+        <script type="text/javascript" src="http://writeclearly.openadvocate.org/oarc/oarc.js"></script>
         <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
         <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.2/angular.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.15/angular-ui-router.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.min.js"></script>
-        <!--<script src="js/jquery-2.1.4.min.js"></script>
+        <script src="js/jquery-2.1.4.min.js"></script>
         <script src="js/bootstrap.min.js"></script>
         <script src="js/angular.min.js"></script>
         <script src="js/angular-ui-router.min.js"></script>
-        <script src="js/lodash.min.js"></script>-->
+        <script src="js/lodash.min.js"></script>
 
         <!-- App -->
         <script src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -1,247 +1,271 @@
-angular.module("app", ["ui.router"]).config(function($stateProvider, $urlRouterProvider) {
-    "use strict";
+angular.module("app", ["ui.router"])
+    //Config
+    .config(function($stateProvider, $urlRouterProvider) {
+        "use strict";
 
-    // Default location...
-    $urlRouterProvider.otherwise("/");
+        // Default location...
+        $urlRouterProvider.otherwise("/");
 
-    // Named states...
-    $stateProvider
-        .state("home", {
-            url: "/",
-            templateUrl: "views/home.html"
-        })
-        .state("acquire", {
-            url: "/acquire",
-            templateUrl: "views/acquire.html"
-        })
-        .state("acquire-in-person", {
-            url: "/acquire-in-person",
-            templateUrl: "views/acquire-in-person.html"
-        })
-        .state("legal", {
-            url: "/legal",
-            templateUrl: "views/legal.html"
-        })
-        .state("eligibility", {
-            url: "/eligibility/:questionId",
-            templateUrl: "views/eligibility.html",
-            controller: "EligibiltyController"
-        })
-        .state("faqs", {
-            url: "/faqs",
-            templateUrl: "views/faqs.html"
-        })
-        .state("definitions", {
-            url: "/definitions",
-            templateUrl: "views/definitions.html"
-        });
-}).controller("EligibiltyController", function EligibilityController(
-    $scope,
-    $http,
-    $window,
-    $state,
-    $stateParams,
-    eligibilityService)
-{
-    "use strict";
-
-    var SUCCESS = "success";
-    var WARNING = "warning";
-    var DANGER = "danger";
-
-    $scope.eligibilityService = eligibilityService;
-
-    $scope.eligibilityKnown = false;
-    $scope.eligibilityFlow = {
-        questions: {},
-        endStates: {}
-    };
-    $scope.eligibilityFlowLength = 0;
-    $scope.currentState = {};
-    $scope.ineligibleMisdemeanors = [];
-    $scope.stateName = "";
-
-    $scope.getLevelClass = function getLevelClass() {
-        switch ($scope.currentState.level) {
-            case SUCCESS: return "alert-success";
-            case WARNING: return "alert-warning";
-            case DANGER: return "alert-danger";
-            default: return "";
-        }
-    };
-
-    $scope.previousQuestion = function previousQuestion() {
-        if ($scope.stateName === $scope.eligibilityFlow.start) {
-            $window.history.back();
-
-            return;
-        }
-
-        if ($scope.eligibilityKnown) {
-            $scope.eligibilityKnown = false;
-        }
-
-        eligibilityService.userInput.pop();
-
-        var previousQuestion = eligibilityService.answeredQuestions.pop();
-
-        $state.go("eligibility", {questionId: previousQuestion});
-        $scope.currentState = $scope.eligibilityFlow.questions[previousQuestion];
-    };
-
-    $scope.restart = function restart() {
-        eligibilityService.userInput = [];
-        eligibilityService.answeredQuestions = [];
-
-        $state.go("eligibility", {questionId: $scope.eligibilityFlow.start});
-        $scope.currentState = $scope.eligibilityFlow.questions[$scope.eligibilityFlow.start];
-    };
-
-    $scope.submitAnswer = function submitAnswer(answerIndex) {
-        // if this question was already answered, cleanup userInput before adding this answer to history
-        if (eligibilityService.answeredQuestions.indexOf($scope.stateName) > -1) {
-            var startDuplication = eligibilityService.answeredQuestions.indexOf($scope.stateName);
-            eligibilityService.userInput.splice(startDuplication, eligibilityService.userInput.length - startDuplication);
-            eligibilityService.answeredQuestions.splice(startDuplication, eligibilityService.answeredQuestions.length - startDuplication);
-        }
-
-        // record this question and answer in record and add to userInput
-        var record = {};
-        record.question = $scope.currentState.questionText;
-        record.answer = $scope.currentState.answers[answerIndex].answerText;
-        eligibilityService.userInput.push(record);
-        eligibilityService.answeredQuestions.push($scope.stateName);
-
-        var next = $scope.currentState.answers[answerIndex].next;
-
-        // check if this answer leads to an eligibility state
-        if (next in $scope.eligibilityFlow.endStates) {
-            $scope.eligibilityKnown = true;
-            $scope.stateName = next;
-            $scope.currentState = $scope.eligibilityFlow.endStates[next];
-            $scope.userInput = eligibilityService.userInput;
-            return;
-        }
-
-        // update currentQuestion if eligibility still not known and next question is valid
-        if (next in $scope.eligibilityFlow.questions) {
-            $scope.stateName = next;
-            $scope.currentState = $scope.eligibilityFlow.questions[next];
-            return;
-        }
-
-        // else if there is no question corresponding to currentQuestion
-        throw new Error("There is no question or endState \'" + next + "\' in $scope.eligibilityFlow.");
-    };
-
-    $scope.progressBar = function progressBar() {
-        var progressPercent = '';
-        //If the current question is an EndState, then set the progess bar to 100
-        if($scope.stateName in $scope.eligibilityFlow.endStates){
-            progressPercent = 100;
-        } else {
-            // Otherwise, divide the number of questions answered by the tree height at this state
-            // multiply by 100, and round
-            var answered = eligibilityService.answeredQuestions.length;
-            progressPercent = Math.round((answered/(answered + $scope.currentState.treeHeight - 1)) * 100);
-        }
-        return progressPercent;
-    };
-
-    $scope.progressBarStyle = function progressBarStyle() {
-        return {
-            "min-width": "2em",
-            width: $scope.progressBar() + "%"
-        };
-    };
-
-    $scope.print = function print() {
-        $window.print();
-    };
-
-    // TODO: Implement e-mail functionality...
-    $scope.email = function email() {};
-
-    function init() {
-        $http.get("data/combined-flow.json").success(function(flow) {
-            $scope.eligibilityFlow = flow;
-
-            eligibilityService.findTreeHeight($scope.eligibilityFlow, $scope.eligibilityFlow.start);
-
-            $scope.eligibilityFlowLength = _.size(_.keys($scope.eligibilityFlow.questions));
-
-            $scope.stateName = $stateParams.questionId;
-
-            if (_.has($scope.eligibilityFlow.endStates, $scope.stateName)) {
-                $scope.eligibilityKnown = true;
-                $scope.currentState = $scope.eligibilityFlow.endStates[$scope.stateName];
-                $scope.userInput = eligibilityService.userInput;
-            }
-            else if (_.has($scope.eligibilityFlow.questions, $scope.stateName)) {
-                $scope.currentState = $scope.eligibilityFlow.questions[$scope.stateName];
-            }
-            else {
-                $state.go("eligibility", {questionId: $scope.eligibilityFlow.start});
-                $scope.currentState = $scope.eligibilityFlow.questions[$scope.eligibilityFlow.start];
-            }
-
-            $http.get("data/ineligible-misdemeanors.json").success(function(data) {
-                $scope.ineligibleMisdemeanors = data;
+        // Named states...
+        $stateProvider
+            .state("home", {
+                url: "/",
+                templateUrl: "views/home.html"
+            })
+            .state("acquire", {
+                url: "/acquire",
+                templateUrl: "views/acquire.html"
+            })
+            .state("acquire-in-person", {
+                url: "/acquire-in-person",
+                templateUrl: "views/acquire-in-person.html"
+            })
+            .state("legal", {
+                url: "/legal",
+                templateUrl: "views/legal.html"
+            })
+            .state("eligibility", {
+                url: "/eligibility/:questionId",
+                templateUrl: "views/eligibility.html",
+                controller: "EligibiltyController"
+            })
+            .state("faqs", {
+                url: "/faqs",
+                templateUrl: "views/faqs.html"
+            })
+            .state("definitions", {
+                url: "/definitions",
+                templateUrl: "views/definitions.html"
             });
-        });
-    }
+    })
+    //Controller
+    .controller("EligibiltyController", function EligibilityController(
+        $scope,
+        $http,
+        $window,
+        $state,
+        $stateParams,
+        eligibilityService)
+    {
+        "use strict";
 
-    init();
-}).service("eligibilityService", function eligibilityService() {
-    "use strict";
+        var SUCCESS = "success";
+        var WARNING = "warning";
+        var DANGER = "danger";
 
-    this.userInput = [];
-    this.answeredQuestions = [];
+        $scope.eligibilityService = eligibilityService;
 
-    this.findTreeHeight = function findTreeHeight(flow, state) {
-        var self = this;
+        $scope.eligibilityKnown = false;
+        $scope.eligibilityFlow = {
+            questions: {},
+            endStates: {}
+        };
+        $scope.eligibilityFlowLength = 0;
+        $scope.currentState = {};
+        $scope.ineligibleMisdemeanors = [];
+        $scope.stateName = "";
 
-        if (_.has(flow.endStates, state)) {
-            flow.endStates[state].treeHeight = 1;
+        $scope.getLevelClass = function getLevelClass() {
+            switch ($scope.currentState.level) {
+                case SUCCESS: return "alert-success";
+                case WARNING: return "alert-warning";
+                case DANGER: return "alert-danger";
+                default: return "";
+            }
+        };
+        $scope.previousQuestion = function previousQuestion() {
+            if ($scope.stateName === $scope.eligibilityFlow.start) {
+                $window.history.back();
 
-            return;
-        }
+                return;
+            }
 
-        if (!_.has(flow.questions, state)) {
-            console.warn(state, "Could not be found in flow.endStates or in flow.questions. PLEASE FIX THIS SOON!");
+            if ($scope.eligibilityKnown) {
+                $scope.eligibilityKnown = false;
+            }
 
-            flow.endStates[state] = {
-                eligiblityText: state + " IS NOT A VALID STATE NAME",
-                icon: "glyphicon glyphicon-alert",
-                helperText: "Something went wrong! We will work on this error and try to fix it soon.",
-                treeHeight: 1
+            eligibilityService.userInput.pop();
+
+            var previousQuestion = eligibilityService.answeredQuestions.pop();
+
+            $state.go("eligibility", {questionId: previousQuestion});
+            $scope.currentState = $scope.eligibilityFlow.questions[previousQuestion];
+        };
+
+        $scope.restart = function restart() {
+            eligibilityService.userInput = [];
+            eligibilityService.answeredQuestions = [];
+
+            $state.go("eligibility", {questionId: $scope.eligibilityFlow.start});
+            $scope.currentState = $scope.eligibilityFlow.questions[$scope.eligibilityFlow.start];
+        };
+
+        $scope.submitAnswer = function submitAnswer(answerIndex) {
+            // if this question was already answered, cleanup userInput before adding this answer to history
+            if (eligibilityService.answeredQuestions.indexOf($scope.stateName) > -1) {
+                var startDuplication = eligibilityService.answeredQuestions.indexOf($scope.stateName);
+                eligibilityService.userInput.splice(startDuplication, eligibilityService.userInput.length - startDuplication);
+                eligibilityService.answeredQuestions.splice(startDuplication, eligibilityService.answeredQuestions.length - startDuplication);
+            }
+
+            // record this question and answer in record and add to userInput
+            var record = {};
+            record.question = $scope.currentState.questionText;
+            record.answer = $scope.currentState.answers[answerIndex].answerText;
+            eligibilityService.userInput.push(record);
+            eligibilityService.answeredQuestions.push($scope.stateName);
+
+            var next = $scope.currentState.answers[answerIndex].next;
+
+            // check if this answer leads to an eligibility state
+            if (next in $scope.eligibilityFlow.endStates) {
+                $scope.eligibilityKnown = true;
+                $scope.stateName = next;
+                $scope.currentState = $scope.eligibilityFlow.endStates[next];
+                $scope.userInput = eligibilityService.userInput;
+                return;
+            }
+
+            // update currentQuestion if eligibility still not known and next question is valid
+            if (next in $scope.eligibilityFlow.questions) {
+                $scope.stateName = next;
+                $scope.currentState = $scope.eligibilityFlow.questions[next];
+                return;
+            }
+
+            // else if there is no question corresponding to currentQuestion
+            throw new Error("There is no question or endState \'" + next + "\' in $scope.eligibilityFlow.");
+        };
+
+        $scope.progressBar = function progressBar() {
+            var progressPercent = '';
+            //If the current question is an EndState, then set the progess bar to 100
+            if($scope.stateName in $scope.eligibilityFlow.endStates){
+                progressPercent = 100;
+            } else {
+                // Otherwise, divide the number of questions answered by the tree height at this state
+                // multiply by 100, and round
+                var answered = eligibilityService.answeredQuestions.length;
+                progressPercent = Math.round((answered/(answered + $scope.currentState.treeHeight - 1)) * 100);
+            }
+            return progressPercent;
+        };
+        $scope.readClearly = function readClearly(){
+            console.log('readClearly Ran')
+            $('#oarc-activate').each(function(i){
+                $(this).remove();
+            });
+            OARC.init(true, 'bottom-right', 'neutral');
+        };
+        $scope.progressBarStyle = function progressBarStyle() {
+            return {
+                "min-width": "2em",
+                width: $scope.progressBar() + "%"
             };
+        };
 
-            return;
+        $scope.print = function print() {
+            $window.print();
+        };
+
+        // TODO: Implement e-mail functionality...
+        $scope.email = function email() {};
+
+        function init() {
+            $http.get("data/combined-flow.json").success(function(flow) {
+                $scope.eligibilityFlow = flow;
+
+                eligibilityService.findTreeHeight($scope.eligibilityFlow, $scope.eligibilityFlow.start);
+
+                $scope.eligibilityFlowLength = _.size(_.keys($scope.eligibilityFlow.questions));
+
+                $scope.stateName = $stateParams.questionId;
+
+                if (_.has($scope.eligibilityFlow.endStates, $scope.stateName)) {
+                    $scope.eligibilityKnown = true;
+                    $scope.currentState = $scope.eligibilityFlow.endStates[$scope.stateName];
+                    $scope.userInput = eligibilityService.userInput;
+                }
+                else if (_.has($scope.eligibilityFlow.questions, $scope.stateName)) {
+                    $scope.currentState = $scope.eligibilityFlow.questions[$scope.stateName];
+                }
+                else {
+                    $state.go("eligibility", {questionId: $scope.eligibilityFlow.start});
+                    $scope.currentState = $scope.eligibilityFlow.questions[$scope.eligibilityFlow.start];
+                }
+
+                $http.get("data/ineligible-misdemeanors.json").success(function(data) {
+                    $scope.ineligibleMisdemeanors = data;
+                });
+            });
         }
 
-        if (_.has(flow.questions[state], "treeHeight")) {
-            return;
-        }
+        init();
+    })
+    //Service
+    .service("eligibilityService", function eligibilityService() {
+        "use strict";
 
-        var question = flow.questions[state];
+        this.userInput = [];
+        this.answeredQuestions = [];
 
-        _.forEach(question.answers, function(answer) {
-            self.findTreeHeight(flow, answer.next);
-        });
+        this.findTreeHeight = function findTreeHeight(flow, state) {
+            var self = this;
 
-        question.treeHeight = 1 + question.answers.reduce(function(maxHeight, answer) {
-            if (_.has(flow.endStates, answer.next)) {
-                return (maxHeight < 1) ? 1 : maxHeight;
+            if (_.has(flow.endStates, state)) {
+                flow.endStates[state].treeHeight = 1;
+
+                return;
             }
 
-            var nextHeight = flow.questions[answer.next].treeHeight;
+            if (!_.has(flow.questions, state)) {
+                console.warn(state, "Could not be found in flow.endStates or in flow.questions. PLEASE FIX THIS SOON!");
 
-            if (nextHeight > maxHeight) {
-                return nextHeight;
+                flow.endStates[state] = {
+                    eligiblityText: state + " IS NOT A VALID STATE NAME",
+                    icon: "glyphicon glyphicon-alert",
+                    helperText: "Something went wrong! We will work on this error and try to fix it soon.",
+                    treeHeight: 1
+                };
+
+                return;
             }
 
-            return maxHeight;
-        }, 0);
-    };
-});
+            if (_.has(flow.questions[state], "treeHeight")) {
+                return;
+            }
+
+            var question = flow.questions[state];
+
+            _.forEach(question.answers, function(answer) {
+                self.findTreeHeight(flow, answer.next);
+            });
+
+            question.treeHeight = 1 + question.answers.reduce(function(maxHeight, answer) {
+                if (_.has(flow.endStates, answer.next)) {
+                    return (maxHeight < 1) ? 1 : maxHeight;
+                }
+
+                var nextHeight = flow.questions[answer.next].treeHeight;
+
+                if (nextHeight > maxHeight) {
+                    return nextHeight;
+                }
+
+                return maxHeight;
+            }, 0);
+        };
+    })
+    //After render directive so that jQuery for ReadClearly works
+    .directive('afterRender', ['$timeout', function ($timeout) {
+        var def = {
+            restrict: 'A',
+            terminal: false,
+            transclude: false,
+            link: function (scope, element, attrs) {
+                $timeout(scope.$eval(attrs.afterRender), 400);  //Calling a scoped method
+            }
+        };
+        console.log(def);
+        return def;
+    }]);

--- a/views/eligibility.html
+++ b/views/eligibility.html
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row" after-render="readClearly">
     <div class="col-lg-12">
         <div class="panel panel-default">
             <!-- Header -->
@@ -16,7 +16,7 @@
             </div>
 
             <!-- Content -->
-            <div class="panel-body">
+            <div class="panel-body openadvocate-content">
                 <!-- Progress bar -->
                 <div class="progress">
                     <div class="progress-bar" ng-style="progressBarStyle()">


### PR DESCRIPTION
Adds pop-up legal dictionary by [Read Clearly](https://openadvocate.org/readclearly/).

Because Read Clearly is jQuery-based and needs to parse its content after the dom has been rendered, I added an additional directive (afterRender) to launch the glossary after the question has been created.

The function also looks for older Read Clearly elements and then removes them if they are present before creating a new one.

To do: the styling could be made more uniform with the current look of clean slate.
