### PR TITLE
Spanish Language Bar

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -4,6 +4,16 @@ body {
     background-size: cover;
 }
 
+.language{
+	background-color:#2B3E50; 
+	text-align:right;
+	padding:5px 40px;
+}
+.language ul{
+	margin:0;
+	list-style-type:none;
+}
+
 .navbar-header {
     height: 64px;
 }

--- a/index.html
+++ b/index.html
@@ -14,20 +14,15 @@
         <link rel="canonical" href="https://cleanslatedc.com">
         <meta property="og:url" content="https://cleanslatedc.com">
 
-        <!-- Google Analytics -->
-        <script>
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-            ga('create', 'UA-65720323-1', 'auto');
-            ga('set', 'anonymizeIp', true);
-        </script>
-        <!-- End Google Analytics -->
     </head>
     <body>
         <nav class="navbar navbar-default navbar-fixed-top" role="navigation" ng-controller="navController">
+		  		<div class="language">
+					<ul>
+						<li><a data-toggle="collapse" ng-show="language === 'en'" data-target="#navbar-content.in" href="#" ng-click="useSpanish()">En Espa&ntilde;ol</a></li>
+                  <li class="hide"><a data-toggle="collapse" ng-hide="language === 'en'" data-target="#navbar-content.in" href="#" ng-click="useEnglish()">English</a></li>
+					</ul>
+				</div>
             <div class="container">
                 <div class="navbar-header">
                     <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="#navbar-content">
@@ -35,9 +30,8 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" ui-sref="home">
-                        <img src="img/logo.jpg" alt="logo" width="200">
-                    </a>
+                    <p>&nbsp;</p>
+                    <p>&nbsp;</p>
                 </div>
                 <div id="navbar-content" class="collapse navbar-collapse">
                     <div class="navbar-right">
@@ -46,8 +40,7 @@
                             <li><a ui-sref="acquire" data-toggle="collapse" data-target="#navbar-content.in">Acquire Your Record/Rap Sheet</a></li>
                             <li><a ui-sref="faqs" data-toggle="collapse" data-target="#navbar-content.in">FAQs</a></li>
                             <li><a ui-sref="definitions" data-toggle="collapse" data-target="#navbar-content.in">Definitions</a></li>
-                            <li><a data-toggle="collapse" ng-show="language === 'en'" data-target="#navbar-content.in" href="#" ng-click="useSpanish()">Espanol</a></li>
-                            <li><a data-toggle="collapse" ng-hide="language === 'en'" data-target="#navbar-content.in" href="#" ng-click="useEnglish()">English</a></li>
+                            
                         </ul>
                     </div>
                 </div>
@@ -70,5 +63,18 @@
 
         <!-- App -->
         <script src="js/app.js"></script>
+		  
+		  
+        <!-- Google Analytics -->
+        <script>
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+            ga('create', 'UA-65720323-1', 'auto');
+            ga('set', 'anonymizeIp', true);
+        </script>
+        <!-- End Google Analytics -->
     </body>
 </html>


### PR DESCRIPTION
Moved Google Analytics to bottom to speed up loading.

Added Spanish option to top. Kept javascript functionality and English
option. When you go to have the real Spanish translation, should be
able to use a simple jquery command to toggle class.

Google form can say: “Be the first to know when this website is available in Spanish”
Spanish translation: “Ser el primero saber cuando este sitio web está disponible en español. Ingrese su email abajo”
