### PR TITLE
Fixed ineligible misdemeanors

### DIFF
--- a/data/combined-flow.json
+++ b/data/combined-flow.json
@@ -874,7 +874,7 @@
         }
       ],
       "helperText": "If the conviction is from somewhere other than DC, have you been convicted of a misdemeanor that is like one of the misdemeanors on the list.",
-      "showIneligibleMisdemeanors": true
+      "showIneligibleMisdemeanors": "true"
     },
     
         "621a": {

--- a/views/eligibility.html
+++ b/views/eligibility.html
@@ -54,11 +54,6 @@
                         </ul>
                     </div>
 
-                    <div class="alert alert-info"
-                         ng-if="currentState.helperText.length"
-                         ng-repeat="text in currentState.helperText track by $index">
-                        <i class="glyphicon glyphicon glyphicon-info-sign"></i> {{ text }}
-                    </div>
                 </div>
 
                 <!-- Unlocked state -->


### PR DESCRIPTION
There was extra code adding a number of boxes on the the page while displaying ineligible misdemeanors. This have been removed.
